### PR TITLE
remove text formatting that looks like yaml

### DIFF
--- a/02-statistical-learning.Rmd
+++ b/02-statistical-learning.Rmd
@@ -1,6 +1,3 @@
----
----
----
 
 # Statistical Learning
 


### PR DESCRIPTION
Trying to isolate the build issue. These `---` blocks seem to be interpreted as yaml even though they are not. Removing them as a first step toward a solution. Stack overflow thread with some discussion: https://stackoverflow.com/questions/19520463/pandoc-cannot-parse-yaml-header-when-converting-md-to-pdf